### PR TITLE
PLANET-7365: Remove deprecated `social` property

### DIFF
--- a/templates/author.twig
+++ b/templates/author.twig
@@ -22,7 +22,7 @@
 					{% endif %}
 				</div>
 				<div class="col-lg-5 col-md-4 col-sm-12 mt-3 mt-md-0">
-					{% include "blocks/share_buttons.twig" with {social:author_share_buttons} %}
+					{% include "blocks/share_buttons.twig" %}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7365

# Description
As a part of p4 code base maintenance we're going to clean up the author listing page and remove [this piece of code](https://github.com/greenpeace/planet4-master-theme/blob/a26bee686afc18305f3aed2ed29ecc45a1c88749/author.php#L38-L42). Before that, we need to make sure that any inherited code from NROs would be broken.

That is why we need to remove the social property from passed to share buttons twig template.

The current pull request does require to be reviewed by the assigned reviewer, in this case is @hi-upchen. The reviewer has been added only to keep him posted with the current and future p4 change.

## Linked PRs
- https://github.com/greenpeace/planet4-child-theme-hongkong/pull/32
- https://github.com/greenpeace/planet4-child-theme-taiwan/pull/30